### PR TITLE
Add a homebrew target for easy install on macs

### DIFF
--- a/jcurl.rb
+++ b/jcurl.rb
@@ -10,7 +10,7 @@ class Jcurl < Formula
     (bin/"jcurl").write <<~EOS
       #!/bin/sh
       
-      java -jar #{prefix}/jcurl.jar
+      java -jar #{prefix}/jcurl.jar "$@"
     EOS
   end
 end

--- a/jcurl.rb
+++ b/jcurl.rb
@@ -6,8 +6,8 @@ class Jcurl < Formula
   sha256 "b4bb73bee7a29b28e18ea7d16f8ed4d6d86222e92da8771e9ff25ac3234acd1c"
 
   def install
-  	prefix.install "jcurl.jar"
-  	(bin/"jcurl").write <<~EOS
+    prefix.install "jcurl.jar"
+    (bin/"jcurl").write <<~EOS
       #!/bin/sh
       
       java -jar #{prefix}/jcurl.jar

--- a/jcurl.rb
+++ b/jcurl.rb
@@ -1,0 +1,16 @@
+class Jcurl < Formula
+  desc "JSON-aware curl in Java"
+  homepage "https://github.com/symphonyoss/JCurl"
+  version "0.9.11"
+  url "https://github.com/symphonyoss/JCurl/releases/download/jcurl-#{version}/jcurl.jar", :nounzip => true
+  sha256 "b4bb73bee7a29b28e18ea7d16f8ed4d6d86222e92da8771e9ff25ac3234acd1c"
+
+  def install
+  	prefix.install "jcurl.jar"
+  	(bin/"jcurl").write <<~EOS
+      #!/bin/sh
+      
+      java -jar #{prefix}/jcurl.jar
+    EOS
+  end
+end


### PR DESCRIPTION
Ideally this would live at https://github.com/symphonyoss/homebrew-tap/jcurl.rb but I can't submit a PR to that location

With that structure it would be installable via

`brew install symphonyoss/tap/jcurl`

To test current file use `brew install jcurl.rb`